### PR TITLE
fix: added the missing functions and fields from base overrides

### DIFF
--- a/odoo_typing_classes_generator/assets/template.py
+++ b/odoo_typing_classes_generator/assets/template.py
@@ -31,6 +31,7 @@ Domain = List[Union[str, tuple]]
 
 
 class AbstractModel(Generic[T]):
+    # odoo-typing-classes-generator: base-insertion-point
     create_date: datetime
     env: Environment
     id: int

--- a/odoo_typing_classes_generator/core/generator.py
+++ b/odoo_typing_classes_generator/core/generator.py
@@ -15,6 +15,7 @@ from typing import (
     Set,
     Union,
     get_type_hints,
+    Tuple,
 )
 
 from odoo import fields, models
@@ -478,6 +479,7 @@ class Generator:
         all_class_definitions = [
             merged_model_data.get_class_definition()
             for merged_model_data in self.merged_models_data_by_odoo_model_name.values()
+            if merged_model_data.odoo_model_name != "base"
         ]
         class_file_content += "\n\n".join(sorted(all_class_definitions))
         return class_file_content
@@ -485,22 +487,63 @@ class Generator:
     def _generate_stub_file_content(self) -> str:
         with open(self.assets_path / "template.py", "r") as template_stub_file:
             stub_file_content = template_stub_file.read()
-        all_import_lines: Set[str] = set()
         all_stub_definitions: List[str] = []
-        model_class_names: Set[str] = set()
-        for merged_model_data in self.merged_models_data_by_odoo_model_name.values():
-            model_class_names.add(merged_model_data.unique_class_name)
-            import_lines, stub_definition = merged_model_data.get_stub_definition(
+        all_import_lines: Set[str] = set()
+        base_class_definition = ""
+        for merged_model_data in self._get_sorted_merged_models_data():
+            definition = merged_model_data.get_stub_definition(
                 self.merged_models_data_by_odoo_model_name
             )
-            all_import_lines.update(import_lines)
-            all_stub_definitions.append(stub_definition)
+            all_import_lines.update(definition.imports)
+            if merged_model_data.odoo_model_name == "base":
+                base_class_definition = definition.content
+            else:
+                all_stub_definitions.append(
+                    f"{definition.signature}{definition.content}"
+                )
         stub_file_content = stub_file_content.replace(
             "# odoo-typing-classes-generator: imports-insertion-point",
             "\n".join(sorted(all_import_lines)) + "\n",
         )
         stub_file_content = stub_file_content.replace(
+            "    # odoo-typing-classes-generator: base-insertion-point",
+            base_class_definition,
+        )
+        stub_file_content = stub_file_content.replace(
             "# odoo-typing-classes-generator: classes-insertion-point",
-            "\n\n".join(sorted(all_stub_definitions)),
+            "\n\n".join(all_stub_definitions),
         )
         return stub_file_content
+
+    def _get_sorted_merged_models_data(self) -> List[MergedModelData]:
+        merged_models_data = sorted(
+            self.merged_models_data_by_odoo_model_name.values(),
+            key=lambda m: m.odoo_model_name,
+        )
+        while True:
+            merged_models_data, changed = self._sort_merged_models_data(
+                merged_models_data
+            )
+            if not changed:
+                break
+        return merged_models_data
+
+    def _sort_merged_models_data(
+        self, merged_models_data: List[MergedModelData]
+    ) -> Tuple[List[MergedModelData], bool]:
+        for index, model_data in enumerate(merged_models_data):
+            inherited_model_names = model_data.inherited_model_names - {
+                model_data.odoo_model_name
+            }
+            if not inherited_model_names:
+                continue
+            for next_index in range(index + 1, len(merged_models_data)):
+                next_model_data = merged_models_data[next_index]
+                if next_model_data.odoo_model_name not in inherited_model_names:
+                    continue
+                merged_models_data[index], merged_models_data[next_index] = (
+                    merged_models_data[next_index],
+                    merged_models_data[index],
+                )
+                return merged_models_data, True
+        return merged_models_data, False

--- a/odoo_typing_classes_generator/core/models.py
+++ b/odoo_typing_classes_generator/core/models.py
@@ -10,10 +10,10 @@ from typing import (
     List,
     Optional,
     Set,
-    Tuple,
     Union,
     get_args,
     get_origin,
+    NamedTuple,
 )
 
 from odoo.tools import ConstantMapping
@@ -21,6 +21,12 @@ from odoo.tools import ConstantMapping
 from ..assets import template as models_typing
 
 _logger = logging.getLogger(__name__)
+
+
+class ClassDefinition(NamedTuple):
+    imports: Set[str]
+    signature: str
+    content: str
 
 
 def _get_field_names_to_ignore_by_class() -> Dict[type, Set[str]]:
@@ -257,7 +263,7 @@ class FieldData:
             ].unique_class_name
             # We cannot use Literal[False] here, because when iterating over the field,
             # the IDE wouldn't know which of the two types the elements have.
-            serialized_type = f'Union["{serialized_type}", bool]'
+            serialized_type = f'Union["{serialized_type}", bool, None]'
         else:
             serialized_type = self.type.serialize()
         field_definition = f"{self.name}: {serialized_type}"
@@ -266,9 +272,6 @@ class FieldData:
                 f"# {field_definition}  # This field name is a Python keyword"
             )
         return f"    {field_definition}"
-
-    def __hash__(self) -> int:
-        return hash((self.name, self.type, self.related))
 
 
 @dataclasses.dataclass
@@ -324,12 +327,12 @@ class ModelData:
     def get_stub_definition(
         self,
         merged_models_data_by_odoo_model_name: Dict[str, "MergedModelData"],
-    ) -> Tuple[Set[str], str]:
+    ) -> ClassDefinition:
         import_classes_to_ignore = {
             model.unique_class_name
             for model in merged_models_data_by_odoo_model_name.values()
         }
-        import_lines: Set[str] = {
+        imports: Set[str] = {
             import_data.serialize()
             for import_data in self.imports
             if import_data.class_name not in import_classes_to_ignore
@@ -342,28 +345,24 @@ class ModelData:
             base_class = models_typing.Model
         field_names_to_ignore = set(field_names_to_ignore_by_class[base_class])
         function_names_to_ignore = set(function_names_to_ignore_by_class[base_class])
-        inherited_classes = [
-            f'"{self.unique_class_name}"',
-        ]
+        inherited_classes = []
         for inherited_model_name in sorted(
             self.inherited_model_names - {self.odoo_model_name}
         ):
             inherited_model_data = merged_models_data_by_odoo_model_name[
                 inherited_model_name
             ]
-            inherited_classes.append(f'"{inherited_model_data.unique_class_name}"')
+            inherited_classes.append(inherited_model_data.unique_class_name)
             for field_name in inherited_model_data.field_data_by_name:
                 field_names_to_ignore.add(field_name)
             for function_name in inherited_model_data.function_data_by_name:
                 function_names_to_ignore.add(function_name)
-        class_definition = f"class {self.unique_class_name}({base_class.__name__}["
-        if len(inherited_classes) == 1:
-            class_definition += inherited_classes[0]
-        else:
-            class_definition += f"Union[{', '.join(inherited_classes)}]"
-        class_definition += "]):\n"
-        class_definition += self._get_class_documentation()
-        class_definition += f'\n    _name = "{self.odoo_model_name}"\n'
+        signature = f"class {self.unique_class_name}("
+        if inherited_classes:
+            signature += f"{', '.join(inherited_classes)}, "
+        signature += f'{base_class.__name__}["{self.unique_class_name}"]):\n'
+        content = self._get_class_documentation()
+        content += f'\n    _name = "{self.odoo_model_name}"\n'
         field_data_by_name = {
             field_name: field_data
             for field_name, field_data in self.field_data_by_name.items()
@@ -375,13 +374,13 @@ class ModelData:
             if function_name not in function_names_to_ignore
         }
         if not field_data_by_name and not function_data_by_name:
-            return import_lines, class_definition
+            return ClassDefinition(imports, signature, content)
         if field_data_by_name:
             field_lines = {
                 field_data.serialize(merged_models_data_by_odoo_model_name)
                 for field_data in field_data_by_name.values()
             }
-            class_definition += "\n" + "\n".join(sorted(field_lines)) + "\n"
+            content += "\n" + "\n".join(sorted(field_lines)) + "\n"
         merged_models_class_names = {
             merged_models_data.unique_class_name
             for merged_models_data in merged_models_data_by_odoo_model_name.values()
@@ -392,14 +391,11 @@ class ModelData:
                 function_data.serialize(escape_pattern)
                 for function_data in function_data_by_name.values()
             }
-            class_definition += "\n" + "\n".join(sorted(function_lines))
-        return import_lines, class_definition
+            content += "\n" + "\n".join(sorted(function_lines))
+        return ClassDefinition(imports, signature, content)
 
     def _get_class_documentation(self) -> str:
         return ""
-
-    def __hash__(self) -> int:
-        return hash(self.unique_class_name)
 
 
 @dataclasses.dataclass

--- a/odoo_typing_classes_generator/tests/test_generator.py
+++ b/odoo_typing_classes_generator/tests/test_generator.py
@@ -8,7 +8,15 @@ import shutil
 import textwrap
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, ForwardRef, Generator, List, Union, get_type_hints
+from typing import (
+    Any,
+    Callable,
+    ForwardRef,
+    Generator,
+    List,
+    Union,
+    get_type_hints,
+)
 from unittest import mock, TestCase
 
 from odoo_typing_classes_generator.core.generator import (
@@ -124,9 +132,8 @@ class TestGenerator(TestCase):
         self.assertEqual(
             members["__orig_bases__"],
             (
-                models_typing.Model[
-                    Union[ForwardRef("FakeModel1"), ForwardRef("ResPartner")]
-                ],
+                models_typing.ResPartner,
+                models_typing.Model[ForwardRef("FakeModel1")],
             ),
         )
         self.assertEqual(
@@ -153,7 +160,7 @@ class TestGenerator(TestCase):
         self.assertIn("a_many_to_one_field", member_annotations)
         self.assertEqual(
             member_annotations["a_many_to_one_field"],
-            Union[ForwardRef("ResCompany"), bool],
+            Union[ForwardRef("ResCompany"), bool, None],
         )
         self.assertIn("a_class_method", members)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,13 +24,8 @@ repository = "https://github.com/alexandregaldeano/odoo-typing-classes-generator
 [project.scripts]
 odoo-typing-classes-generator = "odoo_typing_classes_generator.cli.main:main"
 
-[tool.uv]
-dev-dependencies = [
-  "coverage",
-  "pytest>=8.3.3",
-  "pytest-cov>=3.0.0",
-  "num2words>=0.5.14",
-]
+[dependency-groups]
+dev = ["coverage", "pytest>=8.3.3", "pytest-cov>=3.0.0", "num2words>=0.5.14"]
 
 [build-system]
 requires = ["setuptools>=69", "setuptools_scm[toml]>=6.2"]


### PR DESCRIPTION
Also:
* fixed deprecated use of `tool.uv.dev-dependencies`;
* fixed the signature for correct interpretation by the IDE; and
* added the None assignment to one2Many fields.

Fixes #18 